### PR TITLE
增加用户信息和个性签名，与网站标题，网站描述区分开来

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,9 @@ favicon: /favicon.png
 
 # author headimg
 headimg: http://oct8d1mqf.bkt.clouddn.com/2016-10-17-15%3A42%3A28.jpg
+# author info
+name: Yumemor
+description: Stay Hungry,Stay Foolish.
 
 # search
 search: 

--- a/layout/_partial/author.ejs
+++ b/layout/_partial/author.ejs
@@ -5,8 +5,8 @@
 				<div class="media">
 					<img class="headimg" src='<%=theme.headimg%>' alt='<%=config.author%>'>
 					<div class="media__body">
-						<h4><%=config.title%></h4>
-						<p class='site-description'><%=config.description%></p>
+						<h4><%=theme.name%></h4>
+						<p class='site-description'><%=theme.description%></p>
 					</div>
 				</div>
 				<div class="author-contact">


### PR DESCRIPTION
之前用户头像旁的名字和个签实际上是hexo的config文件里面的网站title和description，在theme的config文件里增加了name和description，以此来区分开来这两部分